### PR TITLE
fix: bcrypt workaround to avoid creation of users in openshift

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -142,13 +142,14 @@ function auth(data) {
 		init(socket, client);
 	} else {
 		var success = false;
+		var salt = bcrypt.genSaltSync(8);
 		_.each(manager.clients, function(client) {
 			if (data.token) {
 				if (data.token === client.token) {
 					success = true;
 				}
 			} else if (client.config.user === data.user) {
-				if (bcrypt.compareSync(data.password || "", client.config.password)) {
+				if (bcrypt.hashSync(data.password, salt) === bcrypt.hashSync(client.config.password, salt)) {
 					success = true;
 				}
 			}


### PR DESCRIPTION
This is a workaround/hack to avoid creation of users inside openshift. It is not the _recommended_ approach to set up a user. Any other approach is highly appriciated
